### PR TITLE
Have backdrop always useNativeDriver={true}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -491,7 +491,7 @@ class ReactNativeModal extends Component {
         <TouchableWithoutFeedback onPress={onBackdropPress}>
           <View
             ref={ref => (this.backdropRef = ref)}
-            useNativeDriver={useNativeDriver}
+            useNativeDriver={true}
             style={[
               styles.backdrop,
               {


### PR DESCRIPTION
The backdrop element is a simple view that only ever has its opacity animated, which _always_ works with `useNativeDriver={true}` (see https://facebook.github.io/react-native/docs/animations#caveats). 

This seems to be a no-brainer non-breaking performance improvement which will give all users a performance boost for free. 